### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE.txt


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file

Wheel distribution now complies with the license:

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.