### PR TITLE
Fix collections import deprecation warning in Python 3.7

### DIFF
--- a/src/pytz/lazy.py
+++ b/src/pytz/lazy.py
@@ -1,8 +1,11 @@
 from threading import RLock
 try:
-    from UserDict import DictMixin
-except ImportError:
-    from collections import Mapping as DictMixin
+    from collections.abc import Mapping as DictMixin
+except ImportError:  # Python < 3.3
+    try:
+        from UserDict import DictMixin  # Python 2
+    except ImportError:  # Python 3.0-3.3
+        from collections import Mapping as DictMixin
 
 
 # With lazy loading, we might end up with multiple threads triggering


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working.