### PR TITLE
Removed naive try/except on unicode builtin to determine Python version

### DIFF
--- a/src/pytz/__init__.py
+++ b/src/pytz/__init__.py
@@ -37,10 +37,7 @@ __all__ = [
 ]
 
 
-try:
-    unicode
-
-except NameError:  # Python 3.x
+if sys.version_info.major > 2:  # Python 3.x
 
     # Python 3.x doesn't have unicode(), making writing code
     # for Python 2.3 and Python 3.x a pain.

--- a/src/pytz/__init__.py
+++ b/src/pytz/__init__.py
@@ -37,7 +37,7 @@ __all__ = [
 ]
 
 
-if sys.version_info.major > 2:  # Python 3.x
+if sys.version_info[0] > 2:  # Python 3.x
 
     # Python 3.x doesn't have unicode(), making writing code
     # for Python 2.3 and Python 3.x a pain.

--- a/src/pytz/tests/test_tzinfo.py
+++ b/src/pytz/tests/test_tzinfo.py
@@ -57,9 +57,7 @@ def prettydt(dt):
         dt.tzname(), offset)
 
 
-try:
-    unicode
-except NameError:
+if sys.version_info.major > 2:
     # Python 3.x doesn't have unicode(), making writing code
     # for Python 2.3 and Python 3.x a pain.
     unicode = str

--- a/src/pytz/tests/test_tzinfo.py
+++ b/src/pytz/tests/test_tzinfo.py
@@ -57,7 +57,7 @@ def prettydt(dt):
         dt.tzname(), offset)
 
 
-if sys.version_info.major > 2:
+if sys.version_info[0] > 2:
     # Python 3.x doesn't have unicode(), making writing code
     # for Python 2.3 and Python 3.x a pain.
     unicode = str


### PR DESCRIPTION
In the case a user has defined a builtin for legacy compatibility, the try/except method naively determines the user must be running Python2 as unicode exists and the try does not raise an Exception.
This makes later internal calls to zone.replace() fail with a TypeError in Python 3 as it attempts to replace str types in a bytes-like object.