### PR TITLE
Brazil Postpones Beginning of DST from November 4 to November 18

### DIFF
--- a/src/pytz/__init__.py
+++ b/src/pytz/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     'NonExistentTimeError', 'UnknownTimeZoneError',
     'all_timezones', 'all_timezones_set',
     'common_timezones', 'common_timezones_set',
+    'BaseTzInfo',
 ]
 
 

--- a/src/pytz/__init__.py
+++ b/src/pytz/__init__.py
@@ -22,8 +22,8 @@ from pytz.tzfile import build_tzinfo
 
 
 # The IANA (nee Olson) database is updated several times a year.
-OLSON_VERSION = '2018e'
-VERSION = '2018.5'  # pip compatible version number.
+OLSON_VERSION = '2018f'
+VERSION = '2018.10'  # pip compatible version number.
 __version__ = VERSION
 
 OLSEN_VERSION = OLSON_VERSION  # Old releases had this misspelling

--- a/src/pytz/tests/test_tzinfo.py
+++ b/src/pytz/tests/test_tzinfo.py
@@ -27,8 +27,8 @@ from pytz.tzinfo import DstTzInfo, StaticTzInfo
 
 # I test for expected version to ensure the correct version of pytz is
 # actually being tested.
-EXPECTED_VERSION = '2018.5'
-EXPECTED_OLSON_VERSION = '2018e'
+EXPECTED_VERSION = '2018.10'
+EXPECTED_OLSON_VERSION = '2018f'
 
 fmt = '%Y-%m-%d %H:%M:%S %Z%z'
 

--- a/tz/southamerica
+++ b/tz/southamerica
@@ -925,7 +925,10 @@ Rule	Brazil	2016	2022	-	Feb	Sun>=15	0:00	0	-
 # ... https://www.timeanddate.com/news/time/brazil-delays-dst-2018.html
 # From Steffen Thorsen (2017-12-20):
 # http://www.planalto.gov.br/ccivil_03/_ato2015-2018/2017/decreto/D9242.htm
-Rule	Brazil	2018	max	-	Nov	Sun>=1	0:00	1:00	-
+# From Juliano Vieira (2018-10-05)
+# Brazil Postpones Beginning of DST from November 4 to November 18
+# https://www.timeanddate.com/news/time/brazil-postpones-dst-2018.html
+Rule	Brazil	2018	max	-	Nov	Sun>=15	0:00	1:00	-
 Rule	Brazil	2023	only	-	Feb	Sun>=22	0:00	0	-
 Rule	Brazil	2024	2025	-	Feb	Sun>=15	0:00	0	-
 Rule	Brazil	2026	only	-	Feb	Sun>=22	0:00	0	-


### PR DESCRIPTION
According to https://www.timeanddate.com/news/time/brazil-postpones-dst-2018.html I'm updating a Rule to start DST on every third Sunday of November