### PR TITLE
Replace all references to deprecated easy_install with pip

### DIFF
--- a/src/README.txt
+++ b/src/README.txt
@@ -31,23 +31,18 @@ Almost all of the Olson timezones are supported.
 Installation
 ~~~~~~~~~~~~
 
-This package can either be installed from a .egg file using setuptools,
-or from the tarball using the standard Python distutils.
+This package can either be installed using ``pip`` or from a tarball using the
+standard Python distutils.
+
+If you are installing using ``pip``, you don't need to download anything as the
+latest version will be downloaded for you from PyPI::
+
+    pip install pytz
 
 If you are installing from a tarball, run the following command as an
 administrative user::
 
     python setup.py install
-
-If you are installing using setuptools, you don't even need to download
-anything as the latest version will be downloaded for you
-from the Python package index::
-
-    easy_install --upgrade pytz
-
-If you already have the .egg file, you can use that too::
-
-    easy_install pytz-2008g-py2.6.egg
 
 
 Example & Usage


### PR DESCRIPTION
easy_install is deprecated and its use is discouraged by PyPA:

https://setuptools.readthedocs.io/en/latest/easy_install.html

> Warning: Easy Install is deprecated. Do not use it. Instead use pip.

Follow upstream advice and only recommended supported tools.