### PR TITLE
Khgitting/allow differently cased timezone constructor arg

### DIFF
--- a/gen_tzinfo.py
+++ b/gen_tzinfo.py
@@ -129,6 +129,7 @@ def add_allzones(filename):
         tz for tz in all_timezones if resource_exists(tz))
         '''
     print >> outf, 'all_timezones_set = LazySet(all_timezones)'
+    print >> outf, '_all_timezones_lower_to_standard = dict((tz.lower(), tz) for tz in all_timezones)'
 
     print >> outf, 'common_timezones = \\'
     pprint(cz, outf)

--- a/src/pytz/__init__.py
+++ b/src/pytz/__init__.py
@@ -166,7 +166,7 @@ def timezone(zone):
         # All valid timezones are ASCII
         raise UnknownTimeZoneError(zone)
 
-    zone = _unmunge_zone(zone)
+    zone = _case_insensitive_zone_lookup(_unmunge_zone(zone))
     if zone not in _tzinfo_cache:
         if zone in all_timezones_set:
             fp = open_resource(zone)
@@ -183,6 +183,11 @@ def timezone(zone):
 def _unmunge_zone(zone):
     """Undo the time zone name munging done by older versions of pytz."""
     return zone.replace('_plus_', '+').replace('_minus_', '-')
+
+
+def _case_insensitive_zone_lookup(zone):
+    """Get case-insensitively matching timezone, if found, else return zone unchanged"""
+    return _all_timezones_lower_to_standard.get(zone.lower()) or zone
 
 
 ZERO = datetime.timedelta(0)

--- a/src/pytz/tests/test_tzinfo.py
+++ b/src/pytz/tests/test_tzinfo.py
@@ -758,6 +758,16 @@ class CommonTimezonesTestCase(unittest.TestCase):
         self.assertFalse('Europe/Belfast' in pytz.common_timezones_set)
 
 
+class ZoneCaseInsensitivityTestCase(unittest.TestCase):
+    def test_lower_case_timezone_constructor_arg(self):
+        for tz in pytz.all_timezones_set:
+            from_lower = pytz.timezone(tz.lower())
+            from_passed = pytz.timezone(tz)
+            self.assertEqual(from_lower,
+                             from_passed,
+                             "arg '{}' and arg '{}' produce different timezone objects".format(from_lower, from_passed))
+
+
 class BaseTzInfoTestCase:
     '''Ensure UTC, StaticTzInfo and DstTzInfo work consistently.
 


### PR DESCRIPTION
This change allows for zone arguments passed to pytz.timezone to be matched against existing timezones without regard to case. For example, where before `pytz.timezone('us/eastern')` would result in an `UnknownTimeZoneError`, now `pytz.timezone('us/eastern')` will succeed and be equivalent to `pytz.timezone('US/Eastern')`

https://answers.launchpad.net/pytz/+question/677307