### PR TITLE
Prepare for the python3 only build

### DIFF
--- a/gen_pot.py
+++ b/gen_pot.py
@@ -1,6 +1,10 @@
+from __future__ import unicode_literals
+
 import sys
 import os.path
 import time
+
+from io import open
 from gen_tzinfo import allzones
 
 from pytz import __version__
@@ -24,14 +28,13 @@ def main():
     if not os.path.exists(os.path.dirname(pot_file_name)):
         os.makedirs(os.path.dirname(pot_file_name))
 
-    pot = open(pot_file_name, 'wb')
+    with open(pot_file_name, 'w', encoding='utf-8') as pot:
+        pot.write(boilerplate + '\n')
 
-    print >> pot, boilerplate
-
-    for zone in allzones():
-        print >> pot, 'msgid "%s"' % zone
-        print >> pot, 'msgstr ""'
-        print >> pot
+        for zone in allzones():
+            pot.write('msgid "%s"\n' % zone)
+            pot.write('msgstr ""\n')
+            pot.write('\n')
 
 
 if __name__ == '__main__':

--- a/gen_tests.py
+++ b/gen_tests.py
@@ -3,13 +3,16 @@
 '''
 $Id: gen_tests.py,v 1.15 2005/01/07 04:51:30 zenzen Exp $
 '''
+from __future__ import unicode_literals
 
 import os
 import os.path
 import subprocess
 import sys
-from gen_tzinfo import allzones
+from io import open
+
 import gen_tzinfo
+from gen_tzinfo import allzones
 
 zdump = os.path.abspath(os.path.join(
     os.path.dirname(__file__), 'build', 'bin', 'zdump'
@@ -19,25 +22,23 @@ zdump = os.path.abspath(os.path.join(
 def main():
     dest_dir = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 
-    datf = open(os.path.join(dest_dir, 'zdump.out'), 'w')
+    with open(os.path.join(dest_dir, 'zdump.out'), 'w') as datf:
+        for zone in allzones():
+            print('Collecting zdump(1) output for %s in zdump.out' % (zone,))
+            # We don't yet support v2 format tzfile(5) files, so limit
+            # the daterange we test against - zdump understands v2 format
+            # files and will output historical records we can't cope with
+            # otherwise.
+            command = [zdump, '-v', '-c', '1902,2038', zone]
+            zd_out = subprocess.check_output(command)
+            # Skip bogus output on 64bit architectures, per Bug #213816
+            lines = [
+                line.decode('utf-8').strip() for line in zd_out.splitlines()
+                if not line.decode('utf-8').strip().endswith('NULL')]
 
-    for zone in allzones():
-        print('Collecting zdump(1) output for %s in zdump.out' % (zone,))
-        # We don't yet support v2 format tzfile(5) files, so limit
-        # the daterange we test against - zdump understands v2 format
-        # files and will output historical records we can't cope with
-        # otherwise.
-        command = [zdump, '-v', '-c', '1902,2038', zone]
-        zd_out = subprocess.check_output(command)
-        # Skip bogus output on 64bit architectures, per Bug #213816
-        lines = [
-            line.strip() for line in zd_out.splitlines()
-            if not line.decode('utf-8').strip().endswith('NULL')]
+            for line in lines:
+                datf.write(line + '\n')
 
-        for line in lines:
-            print >> datf, line
-    datf.flush()
-    datf.close()
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
This change allows to run pytz builds on systems which have Python 3 as /usr/bin/python without breaking existing Python 2.7 builds.