### PR TITLE
Travis CI: Sudo is a deprecated tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 # vim: set filetype=yaml sw=2:
-sudo: required
 dist: bionic
 addons:
   apt:


### PR DESCRIPTION
All mention of the `sudo:` tag has been removed from Travis CI docs.

Output: https://travis-ci.org/github/stub42/pytz