### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
           cd build/dist/pytz/tests
           python test_docs.py -vv
       - name: zdump Tests
-        if: ${{ matrix.python-version == '3.10' }}
+        if: ${{ matrix.python-version == '3.11' }}
         run: |
           python gen_tests.py
           python test_zdump.py -vv

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ PYTHON37=python3.7
 PYTHON38=python3.8
 PYTHON39=python3.9
 PYTHON310=python3.10
+PYTHON311=python3.11
 PYTHON2=/usr/bin/python2
 PYTHON3=/usr/bin/python3
 PYTHON=${PYTHON3}
@@ -82,7 +83,8 @@ test_lazy: .stamp-tzinfo
 	    && ${PYTHON37} test_lazy.py ${TESTARGS} \
 	    && ${PYTHON38} test_lazy.py ${TESTARGS} \
 	    && ${PYTHON39} test_lazy.py ${TESTARGS} \
-	    && ${PYTHON310} test_lazy.py ${TESTARGS}
+	    && ${PYTHON310} test_lazy.py ${TESTARGS} \
+	    && ${PYTHON311} test_lazy.py ${TESTARGS}
 
 test_tzinfo: .stamp-tzinfo
 	cd build/dist/pytz/tests \
@@ -99,7 +101,8 @@ test_tzinfo: .stamp-tzinfo
 	    && ${PYTHON37} test_tzinfo.py ${TESTARGS} \
 	    && ${PYTHON38} test_tzinfo.py ${TESTARGS} \
 	    && ${PYTHON39} test_tzinfo.py ${TESTARGS} \
-	    && ${PYTHON310} test_tzinfo.py ${TESTARGS}
+	    && ${PYTHON310} test_tzinfo.py ${TESTARGS} \
+	    && ${PYTHON311} test_tzinfo.py ${TESTARGS}
 
 test_docs: .stamp-tzinfo
 	cd build/dist/pytz/tests \
@@ -110,7 +113,7 @@ test_zdump: dist
 	${PYTHON3} gen_tests.py ${TARGET} && \
 	${PYTHON3} test_zdump.py ${TESTARGS} && \
 	${PYTHON2} test_zdump.py ${TESTARGS} && \
-	${PYTHON310} test_zdump.py ${TESTARGS}
+	${PYTHON311} test_zdump.py ${TESTARGS}
 
 build/dist/test_zdump.py: .stamp-zoneinfo
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -63,6 +63,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk).

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)
