### PR TITLE
Replace deprecated datetime.utcfromtimestamp()

### DIFF
--- a/src/README.rst
+++ b/src/README.rst
@@ -148,7 +148,7 @@ section for more details)
 Converting between timezones is more easily done, using the
 standard astimezone method.
 
->>> utc_dt = utc.localize(datetime.utcfromtimestamp(1143408899))
+>>> utc_dt = datetime.fromtimestamp(1143408899, tz=utc)
 >>> utc_dt.strftime(fmt)
 '2006-03-26 21:34:59 UTC+0000'
 >>> au_tz = timezone('Australia/Sydney')
@@ -166,7 +166,7 @@ conversions. ``normalize()`` and ``localize()`` are not really
 necessary when there are no daylight saving time transitions to
 deal with.
 
->>> utc_dt = datetime.utcfromtimestamp(1143408899).replace(tzinfo=utc)
+>>> utc_dt = datetime.fromtimestamp(1143408899, tz=utc)
 >>> utc_dt.strftime(fmt)
 '2006-03-26 21:34:59 UTC+0000'
 >>> au_tz = timezone('Australia/Sydney')
@@ -605,4 +605,3 @@ Contact
 ~~~~~~~
 
 Stuart Bishop <stuart@stuartbishop.net>
-

--- a/src/pytz/tests/test_tzinfo.py
+++ b/src/pytz/tests/test_tzinfo.py
@@ -539,7 +539,7 @@ class NoumeaDSTEndTestCase(USEasternDSTStartTestCase):
 
 
 class NoumeaNoMoreDSTTestCase(NoumeaDSTEndTestCase):
-    # Noumea dropped DST in 1997. Here we test that it stops occuring.
+    # Noumea dropped DST in 1997. Here we test that it stops occurring.
     transition_time = (
         NoumeaDSTEndTestCase.transition_time + timedelta(days=365 * 10))
     before = NoumeaDSTEndTestCase.after

--- a/src/pytz/tzinfo.py
+++ b/src/pytz/tzinfo.py
@@ -355,7 +355,7 @@ class DstTzInfo(BaseTzInfo):
                     is_dst=False) + timedelta(hours=6)
 
         # If we get this far, we have multiple possible timezones - this
-        # is an ambiguous case occuring during the end-of-DST transition.
+        # is an ambiguous case occurring during the end-of-DST transition.
 
         # If told to be strict, raise an exception since we have an
         # ambiguous case

--- a/src/pytz/tzinfo.py
+++ b/src/pytz/tzinfo.py
@@ -1,6 +1,6 @@
 '''Base classes and helpers for building zone specific tzinfo classes'''
 
-from datetime import datetime, timedelta, tzinfo
+from datetime import datetime, timedelta, timezone, tzinfo
 from bisect import bisect_right
 try:
     set
@@ -24,7 +24,7 @@ def memorized_timedelta(seconds):
         _timedelta_cache[seconds] = delta
         return delta
 
-_epoch = datetime.utcfromtimestamp(0)
+_epoch = datetime.fromtimestamp(0, tz=timezone.utc)
 _datetime_cache = {0: _epoch}
 
 
@@ -33,7 +33,7 @@ def memorized_datetime(seconds):
     try:
         return _datetime_cache[seconds]
     except KeyError:
-        # NB. We can't just do datetime.utcfromtimestamp(seconds) as this
+        # NB. We can't just do datetime.fromtimestamp(seconds, tz=timezone.utc) as this
         # fails with negative values under Windows (Bug #90096)
         dt = _epoch + timedelta(seconds=seconds)
         _datetime_cache[seconds] = dt

--- a/src/pytz/tzinfo.py
+++ b/src/pytz/tzinfo.py
@@ -24,7 +24,7 @@ def memorized_timedelta(seconds):
         _timedelta_cache[seconds] = delta
         return delta
 
-_epoch = datetime.fromtimestamp(0, tz=timezone.utc)
+_epoch = datetime.fromtimestamp(0, tz=timezone.utc).replace(tzinfo=None)
 _datetime_cache = {0: _epoch}
 
 
@@ -33,8 +33,8 @@ def memorized_datetime(seconds):
     try:
         return _datetime_cache[seconds]
     except KeyError:
-        # NB. We can't just do datetime.fromtimestamp(seconds, tz=timezone.utc) as this
-        # fails with negative values under Windows (Bug #90096)
+        # NB. We can't just do datetime.fromtimestamp(seconds, tz=timezone.utc).replace(tzinfo=None)
+        # as this fails with negative values under Windows (Bug #90096)
         dt = _epoch + timedelta(seconds=seconds)
         _datetime_cache[seconds] = dt
         return dt


### PR DESCRIPTION
Starting with 3.12, `datetime.utcfromtimestamp(...)` is deprecated and should be replaced with `datetime.fromtimestamp(..., tz=utc).replace(tzinfo=None)`.
https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcfromtimestamp

Fixes: https://github.com/stub42/pytz/issues/105