### PR TITLE
Updating Tehran Timezone

### DIFF
--- a/tz/asia
+++ b/tz/asia
@@ -1621,8 +1621,8 @@ Rule	Iran	2021	2022	-	Sep	21	24:00	0	-
 Zone	Asia/Tehran	3:25:44	-	LMT	1916
 			3:25:44	-	TMT	1935 Jun 13 # Tehran Mean Time
 			3:30	Iran	+0330/+0430 1977 Oct 20 24:00
-			3:30	Iran	+04/+05	1979
-			3:30	Iran	+0330/+0430
+			4:30	Iran	+04/+05	1979
+			3:30	Iran	+0330
 
 
 # Iraq

--- a/tz/asia
+++ b/tz/asia
@@ -1621,7 +1621,7 @@ Rule	Iran	2021	2022	-	Sep	21	24:00	0	-
 Zone	Asia/Tehran	3:25:44	-	LMT	1916
 			3:25:44	-	TMT	1935 Jun 13 # Tehran Mean Time
 			3:30	Iran	+0330/+0430 1977 Oct 20 24:00
-			4:00	Iran	+04/+05	1979
+			3:30	Iran	+04/+05	1979
 			3:30	Iran	+0330/+0430
 
 

--- a/tz/zone.tab
+++ b/tz/zone.tab
@@ -215,7 +215,7 @@ IM	+5409-00428	Europe/Isle_of_Man
 IN	+2232+08822	Asia/Kolkata
 IO	-0720+07225	Indian/Chagos
 IQ	+3321+04425	Asia/Baghdad
-IR	+3540+05126	Asia/Tehran
+IR +0330+05126 Asia/Tehran
 IS	+6409-02151	Atlantic/Reykjavik
 IT	+4154+01229	Europe/Rome
 JE	+491101-0020624	Europe/Jersey

--- a/tz/zone1970.tab
+++ b/tz/zone1970.tab
@@ -178,7 +178,7 @@ IL	+314650+0351326	Asia/Jerusalem
 IN	+2232+08822	Asia/Kolkata
 IO	-0720+07225	Indian/Chagos
 IQ	+3321+04425	Asia/Baghdad
-IR	+3540+05126	Asia/Tehran
+IR +0330+05126 Asia/Tehran
 IT,SM,VA	+4154+01229	Europe/Rome
 JM	+175805-0764736	America/Jamaica
 JO	+3157+03556	Asia/Amman


### PR DESCRIPTION
Starting from January 2023, Tehran bid farewell to the practice of maintaining two distinct time zones for winter and summer. Instead, a consistent time offset of +3:30 has been adopted throughout the year. 

regards,

source : https://time.is/Tehran