### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.12"]
 
     steps:
       - uses: actions/checkout@v3
@@ -51,6 +51,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel flake8

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ PYTHON38=python3.8
 PYTHON39=python3.9
 PYTHON310=python3.10
 PYTHON311=python3.11
+PYTHON312=python3.12
 PYTHON2=/usr/bin/python2
 PYTHON3=/usr/bin/python3
 PYTHON=${PYTHON3}
@@ -84,7 +85,8 @@ test_lazy: .stamp-tzinfo
 	    && ${PYTHON38} test_lazy.py ${TESTARGS} \
 	    && ${PYTHON39} test_lazy.py ${TESTARGS} \
 	    && ${PYTHON310} test_lazy.py ${TESTARGS} \
-	    && ${PYTHON311} test_lazy.py ${TESTARGS}
+	    && ${PYTHON311} test_lazy.py ${TESTARGS} \
+	    && ${PYTHON312} test_lazy.py ${TESTARGS}
 
 test_tzinfo: .stamp-tzinfo
 	cd build/dist/pytz/tests \
@@ -102,7 +104,8 @@ test_tzinfo: .stamp-tzinfo
 	    && ${PYTHON38} test_tzinfo.py ${TESTARGS} \
 	    && ${PYTHON39} test_tzinfo.py ${TESTARGS} \
 	    && ${PYTHON310} test_tzinfo.py ${TESTARGS} \
-	    && ${PYTHON311} test_tzinfo.py ${TESTARGS}
+	    && ${PYTHON311} test_tzinfo.py ${TESTARGS} \
+	    && ${PYTHON312} test_tzinfo.py ${TESTARGS}
 
 test_docs: .stamp-tzinfo
 	cd build/dist/pytz/tests \

--- a/src/setup.py
+++ b/src/setup.py
@@ -64,6 +64,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )


### PR DESCRIPTION
The [Python 3.12 release candidate is out!](https://discuss.python.org/t/python-3-12-0-release-candidate-1-released/31137?u=hugovk) :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

See also https://dev.to/hugovk/help-test-python-312-beta-1508/