### PR TITLE
add Canada/Saskatchewan and Canada/Yukon to common timezones

### DIFF
--- a/gen_tzinfo.py
+++ b/gen_tzinfo.py
@@ -110,7 +110,8 @@ def add_allzones(filename):
         'US/Central', 'US/Arizona', 'US/Hawaii', 'US/Alaska',
         # Canadian timezones per Bug #506341
         'Canada/Newfoundland', 'Canada/Atlantic', 'Canada/Eastern',
-        'Canada/Central', 'Canada/Mountain', 'Canada/Pacific'])
+        'Canada/Central', 'Canada/Mountain', 'Canada/Pacific',
+        'Canada/Saskatchewan', 'Canada/Yukon'])
     # And extend out list with all preferred country timezones.
     zone_tab = open(os.path.join(zoneinfo, 'zone.tab'), 'r')
     for line in zone_tab:


### PR DESCRIPTION
Saskatchewan doesn't observe daylight savings. Only having Canada/Central in the common timezone makes you assume that Saskatchatoon is part of Canada/Central but in reality it's mapped to Winnipeg. So the time is actually wrong for half the year if you don't know you need to search for America/Regina, eh!