### PR TITLE
try to access resource using `importlib.resources`

### DIFF
--- a/src/pytz/__init__.py
+++ b/src/pytz/__init__.py
@@ -95,6 +95,16 @@ def open_resource(name):
         filename = os.path.join(os.path.dirname(__file__),
                                 'zoneinfo', *name_parts)
         if not os.path.exists(filename):
+            # pkg_resources is deprecated, try with importlib first
+            try:
+                from importlib.resources import files
+            except ImportError:
+                files = None
+
+            if files is not None:
+                # retrieve the zoneinfo file Path object and return its file handle
+                return files(__name__).joinpath('zoneinfo', *name_parts).open('rb')
+
             # http://bugs.launchpad.net/bugs/383171 - we avoid using this
             # unless absolutely necessary to help when a broken version of
             # pkg_resources is installed.


### PR DESCRIPTION
`pkg_resources` is now deprecated and will throw a `DeprecationWarning` when importing, try and use the replacement `importlib.resources` (Python 3.7+) if available. Details on the deprecation process available here: https://setuptools.pypa.io/en/latest/pkg_resources.html