### PR TITLE
Explicitly close zone_tab file to prevent resource leak

### DIFF
--- a/gen_tzinfo.py
+++ b/gen_tzinfo.py
@@ -119,6 +119,7 @@ def add_allzones(filename):
         code, coordinates, zone = line.split(None, 4)[:3]
         if zone not in cz:
             cz.append(zone)
+    zone_tab.close()
     cz.sort()
 
     print('_all_timezones_unchecked = \\', file=outf)


### PR DESCRIPTION
This PR ensures that the `zone_tab` file is properly closed after being opened. Previously, the file was not explicitly closed, which could lead to resource leaks.