### PR TITLE
Add GitHub Project URLs to Python package

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -39,6 +39,10 @@ setup(
     packages=packages,
     package_data=package_data,
     download_url='https://pypi.org/project/pytz/',
+    project_urls={
+        'Source': 'https://github.com/stub42/pytz.git',
+        'Issues': 'https://github.com/stub42/pytz/issues',
+    },
     platforms=['Independent'],
     classifiers=[
         'Development Status :: 6 - Mature',


### PR DESCRIPTION
Closes #121

This PR also adds a link to the issue tracker.

P.S. [The website](https://pythonhosted.org/pytz/) also names `https://git.launchpad.net/pytz` as a source, but it hasn't been updated since 2022. Is it dead? Should it be removed from that index page? Is the website itself up-to-date? Maybe we should remove its URL from the package altogether?