### PR TITLE
Replace non-ASCII character in comment to fix build with Python 2

### DIFF
--- a/src/pytz/tzfile.py
+++ b/src/pytz/tzfile.py
@@ -97,7 +97,7 @@ def build_tzinfo(zone, fp):
 
                 # Bad dst? Look further. DST > 24 hours happens when
                 # a timezone has moved across the international dateline.
-                # DST <= 0 can be a zone realignment (e.g. Vilnius MSK→CEST); 
+                # DST <= 0 can be a zone realignment (e.g. Vilnius MSK->CEST); 
                 # or legitimate negative DST (e.g. Morocco, Ireland).
                 if dst <= 0 or dst > 3600 * 3:
                     for j in range(i + 1, len(transitions)):


### PR DESCRIPTION
2026.3 doesn't build with Python 2, because 4bf5dd461b07c659fa68d938e64efeda2e626e95 added a UTF-8 character to a comment without adding an encoding declaration. Replace the character with an ASCII equivalent.

(We could instead add an encoding declaration, but none of the other files have them...)